### PR TITLE
templates: extend support for Project Treble ODM partitions

### DIFF
--- a/data/policygroups/ubuntu/1.1/webview
+++ b/data/policygroups/ubuntu/1.1/webview
@@ -100,6 +100,7 @@
     /{,android/}vendor/lib{,64}/*.so        mr,
     /{,android/}system/lib{,64}/*.so        mr,
     /{,android/}system/vendor/lib{,64}/*.so mr,
+    /{,android/}odm/lib{,64}/*.so mr,
     /{,android/}system/build.prop      r,
     /dev/socket/property_service rw, # attach_disconnected path
 

--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -339,12 +339,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -302,12 +302,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -338,12 +338,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -309,12 +309,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.2/ubuntu-account-plugin
+++ b/data/templates/ubuntu/1.2/ubuntu-account-plugin
@@ -171,12 +171,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.2/ubuntu-scope-network
+++ b/data/templates/ubuntu/1.2/ubuntu-scope-network
@@ -22,12 +22,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -338,12 +338,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/data/templates/ubuntu/15.10/ubuntu-account-plugin
+++ b/data/templates/ubuntu/15.10/ubuntu-account-plugin
@@ -171,12 +171,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,

--- a/pending/templates/ubuntu-scope-local-content
+++ b/pending/templates/ubuntu-scope-local-content
@@ -24,12 +24,16 @@
   #  /android/vendor/lib{,64}
   #  /android/system/lib{,64}
   #  /android/system/vendor/lib{,64}
+  #  /odm/lib{,64}
+  #  /android/odm/lib{,64}/
   /{,android/}vendor/lib{,64}/**           r,
   /{,android/}vendor/lib{,64}/**.so        m,
   /{,android/}system/lib{,64}/**           r,
   /{,android/}system/lib{,64}/**.so        m,
   /{,android/}system/vendor/lib{,64}/**    r,
   /{,android/}system/vendor/lib{,64}/**.so m,
+  /{,android/}odm/lib{,64}/**    r,
+  /{,android/}odm/lib{,64}/**.so m,
 
   # attach_disconnected path
   /dev/socket/property_service rw,


### PR DESCRIPTION
This is the bare minimum required for devices using the
/odm partition and subdirectory scheme, like the Sony Loire
platform of devices (Xperia X) to run click applications.

Extending by other packaging mechanisms (....*snap*) might require upstream
communication, but it's not a necessity to properly account for
device specific integration and extension of default AppArmor access rules.
Sooner or later we might have to change defaults due to the nature of device-specific quirks.