### PR TITLE
templates: allow reading media_codecs.xml's subfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -475,7 +475,7 @@
   deny /{,var/}run/user/*/orcexec* w,
   deny @{HOME}/orcexec* w,
 
-  /{,android/}system/etc/media_codecs.xml r,
+  /{,android/}system/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -420,7 +420,7 @@
   deny /{,var/}run/user/*/orcexec* w,
   deny @{HOME}/orcexec* w,
 
-  /{,android/}system/etc/media_codecs.xml r,
+  /{,android/}system/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # system user scripts

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -471,7 +471,7 @@
   deny /{,var/}run/user/*/orcexec* w,
   deny @{HOME}/orcexec* w,
 
-  /{,android/}system/etc/media_codecs.xml r,
+  /{,android/}system/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -424,7 +424,7 @@
   deny /{,var/}run/user/*/orcexec* w,
   deny @{HOME}/orcexec* w,
 
-  /{,android/}system/etc/media_codecs.xml r,
+  /{,android/}system/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # system user scripts

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -451,7 +451,7 @@
   deny /{,var/}run/user/*/orcexec* w,
   deny @{HOME}/orcexec* w,
 
-  /{,android/}system/etc/media_codecs.xml r,
+  /{,android/}system/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now


### PR DESCRIPTION
Newer Android devices tend to write media_codecs.xml which include other
media_codecs_*.xml files. For example, FP2's media_codecs.xml in Halium
7.1 includes media_codecs_google_audio.xml, media_codecs_google
_telephony.xml, media_codecs_google_video.xml and media_codecs_ffmpeg
.xml.

This commit allow reading those files in the templates. The rule is
adapted from the restriction placed by libstagefright itself [2].

This PR comes with Jenkinsfile update.

[1] https://github.com/Halium/android_device_fairphone_FP2/blob/halium-7.1/media/media_codecs_8974.xml
[2] https://github.com/Halium/android_frameworks_av/blob/e37db014adff5dd06754c4b459c95149d8594e7b/media/libstagefright/MediaCodecList.cpp#L420