### PR TITLE
Allow access to qt5 translations and libraries in /usr/lib or /lib

### DIFF
--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -48,6 +48,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # Allow starting services on the system bus (actual communications with
   # the service are mediated elsewhere)
   dbus (send)
@@ -426,11 +431,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -433,6 +433,12 @@
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
+  #
   # cordova-ubuntu
   #
   /usr/share/cordova-ubuntu*/      r,

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -383,6 +383,12 @@
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
+  #
   # webbrowser-app
   #
   /usr/share/webbrowser-app/   r,

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -48,6 +48,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # Unity shell
   dbus (send)
        bus=session
@@ -376,11 +381,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -432,6 +432,12 @@
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
+  #
   # cordova-ubuntu
   #
   /usr/share/cordova-ubuntu*/      r,

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -45,6 +45,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # Unity shell
   dbus (send)
        bus=session
@@ -425,11 +430,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -390,6 +390,12 @@
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
+  #
   # webbrowser-app
   #
   /usr/share/webbrowser-app/   r,

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -45,6 +45,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # Unity shell
   dbus (send)
        bus=session
@@ -383,11 +388,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/1.2/ubuntu-account-plugin
+++ b/data/templates/ubuntu/1.2/ubuntu-account-plugin
@@ -42,6 +42,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # on screen keyboard (OSK)
   dbus (send)
        bus=session
@@ -221,11 +226,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/1.2/ubuntu-account-plugin
+++ b/data/templates/ubuntu/1.2/ubuntu-account-plugin
@@ -227,6 +227,12 @@
   #
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
+  #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
   # Launching under upstart requires this
   /usr/bin/qtchooser rmix,
 

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -432,6 +432,12 @@
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
+  #
   # cordova-ubuntu
   #
   /usr/share/cordova-ubuntu*/      r,

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -45,6 +45,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # Unity shell
   dbus (send)
        bus=session
@@ -425,11 +430,6 @@
 
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/15.10/ubuntu-account-plugin
+++ b/data/templates/ubuntu/15.10/ubuntu-account-plugin
@@ -42,6 +42,11 @@
   # services aren't a secret.
   #include <abstractions/dbus-strict>
 
+  # If apps are reading system library or Qt cache files, they will likely need
+  # to execute them as well.
+  /lib/**.{so,jsc,qmlc,so.*} m,
+  /usr/lib/**.{so,jsc,qmlc,so.*} m,
+
   # on screen keyboard (OSK)
   dbus (send)
        bus=session
@@ -218,11 +223,6 @@
   /usr/share/qtchooser/** r,
   /usr/lib/@{multiarch}/qt5/bin/qmlscene ixr,
   /usr/lib/qt5/bin/qmlscene ixr,
-
-  #
-  # Compiled QML files from the system should always be executable
-  #
-  /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
   #
   # Applications can always try to load Qt's translations

--- a/data/templates/ubuntu/15.10/ubuntu-account-plugin
+++ b/data/templates/ubuntu/15.10/ubuntu-account-plugin
@@ -224,6 +224,12 @@
   #
   /usr/lib/@{multiarch}/qt5/qml/**/*.qmlc m,
 
+  #
+  # Applications can always try to load Qt's translations
+  #
+  /usr/share/qt5/translations/ r,
+  /usr/share/qt5/translations/** r,
+
   owner @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini rk,
   audit deny @{HOME}/.config/{UITK,ubuntu-ui-toolkit}/theme.ini w,
 


### PR DESCRIPTION
Ref. https://forums.ubports.com/topic/4646/unable-to-import-sqlite3-module-in-pyotherside-based-click-application-on-ubuntu-touch-pinephone-stable-channel/2

It appears that more recent Linux kernels enforce mmap protections better than our old Android forked kernels do. Apps are receiving denials trying to, for example:

* import a compiled Python module like json or sqlite3
* import a QML module that happens to have a jsc file

Allowing the 'm' profile on these files does not cause them to also receive the 'r' profile, so any explicit denies of reading still apply.

Allowing access to the Qt translation files doesn't seem absolutely necessary, but I don't have a compelling reason to block them and continue to get the denials.