### PR TITLE
templates: Extend media_codecs loading from vendor partition

### DIFF
--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -486,6 +486,7 @@
   deny @{HOME}/orcexec* w,
 
   /{,android/}system/etc/media_codecs{,_*}.xml r,
+  /{,android/}vendor/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -431,6 +431,7 @@
   deny @{HOME}/orcexec* w,
 
   /{,android/}system/etc/media_codecs{,_*}.xml r,
+  /{,android/}vendor/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # system user scripts

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -482,6 +482,7 @@
   deny @{HOME}/orcexec* w,
 
   /{,android/}system/etc/media_codecs{,_*}.xml r,
+  /{,android/}vendor/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -435,6 +435,7 @@
   deny @{HOME}/orcexec* w,
 
   /{,android/}system/etc/media_codecs{,_*}.xml r,
+  /{,android/}vendor/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # system user scripts

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -462,6 +462,7 @@
   deny @{HOME}/orcexec* w,
 
   /{,android/}system/etc/media_codecs{,_*}.xml r,
+  /{,android/}vendor/etc/media_codecs{,_*}.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Don't allow plugins in webviews for now


### PR DESCRIPTION
Halium 9.0 ports might ship their media_codecs configuration
in the vendor partition, so allow loading from there.