### PR TITLE
Also allow link for files where we allow write.

### DIFF
--- a/data/policygroups/ubuntu/1.0/picture_files
+++ b/data/policygroups/ubuntu/1.0/picture_files
@@ -4,10 +4,10 @@
 #  API to access picture files instead.
 # Usage: reserved
 owner @{HOME}/Pictures/   r,
-owner @{HOME}/Pictures/** rwk,
+owner @{HOME}/Pictures/** rwkl,
 # SD card: /media/<user>/<label>/...
 owner /media/*/*/[Pp][Ii][Cc][Tt][Uu][Rr][Ee][Ss]/   r,
-owner /media/*/*/[Pp][Ii][Cc][Tt][Uu][Rr][Ee][Ss]/** rwk,
+owner /media/*/*/[Pp][Ii][Cc][Tt][Uu][Rr][Ee][Ss]/** rwkl,
 # LP: #1408772. Temporarily allow read to user directory in SD card to obtain
 # the label of the SD card (don't use owner because this directory is owned by
 # root).

--- a/data/policygroups/ubuntu/1.1/music_files
+++ b/data/policygroups/ubuntu/1.1/music_files
@@ -4,10 +4,10 @@
 #  access music files instead.
 # Usage: reserved
 owner @{HOME}/Music/   r,
-owner @{HOME}/Music/** rwk,
+owner @{HOME}/Music/** rwkl,
 # SD card: /media/<user>/<label>/...
 owner /media/*/*/[Mm][Uu][Ss][Ii][Cc]/   r,
-owner /media/*/*/[Mm][Uu][Ss][Ii][Cc]/** rwk,
+owner /media/*/*/[Mm][Uu][Ss][Ii][Cc]/** rwkl,
 # LP: #1408772. Temporarily allow read to user directory in SD card to obtain
 # the label of the SD card (don't use owner because this directory is owned by
 # root).

--- a/data/policygroups/ubuntu/1.1/video_files
+++ b/data/policygroups/ubuntu/1.1/video_files
@@ -4,10 +4,10 @@
 #  access video files instead.
 # Usage: reserved
 owner @{HOME}/Videos/   r,
-owner @{HOME}/Videos/** rwk,
+owner @{HOME}/Videos/** rwkl,
 # SD card: /media/<user>/<label>/...
 owner /media/*/*/[Vv][Ii][Dd][Ee][Oo][Ss]/   r,
-owner /media/*/*/[Vv][Ii][Dd][Ee][Oo][Ss]/** rwk,
+owner /media/*/*/[Vv][Ii][Dd][Ee][Oo][Ss]/** rwkl,
 # LP: #1408772. Temporarily allow read to user directory in SD card to obtain
 # the label of the SD card (don't use owner because this directory is owned by
 # root).

--- a/data/policygroups/ubuntu/16.04/document_files
+++ b/data/policygroups/ubuntu/16.04/document_files
@@ -4,10 +4,10 @@
 #  access document files instead.
 # Usage: reserved
 owner @{HOME}/Documents/   r,
-owner @{HOME}/Documents/** rwk,
+owner @{HOME}/Documents/** rwkl,
 # SD card: /media/<user>/<label>/...
 owner /media/*/*/[Dd][Oo][Cc][Uu][Mm][Ee][Nn][Tt][Ss]/   r,
-owner /media/*/*/[Dd][Oo][Cc][Uu][Mm][Ee][Nn][Tt][Ss]/** rwk,
+owner /media/*/*/[Dd][Oo][Cc][Uu][Mm][Ee][Nn][Tt][Ss]/** rwkl,
 # LP: #1408772. Temporarily allow read to user directory in SD card to obtain
 # the label of the SD card (don't use owner because this directory is owned by
 # root).


### PR DESCRIPTION
Later versions of QFile::copy create temporary files and links in order
to perform copy more reliably, so we need to allow links in the places where
we already allow writes and weren't allowing links, for this to succeed.