### PR TITLE
templates: Use 'mediate_deleted' flag for profiles

### DIFF
--- a/data/templates/ubuntu/1.0/ubuntu-sdk
+++ b/data/templates/ubuntu/1.0/ubuntu-sdk
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   # Temporary fix until LP: #1278702 is fixed in apparmor fonts abstraction

--- a/data/templates/ubuntu/1.0/ubuntu-webapp
+++ b/data/templates/ubuntu/1.0/ubuntu-webapp
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   # Temporary fix until LP: #1278702 is fixed in apparmor fonts abstraction

--- a/data/templates/ubuntu/1.0/unconfined
+++ b/data/templates/ubuntu/1.0/unconfined
@@ -17,7 +17,7 @@
 # ###PROFILEATTACH### (unconfined) {}
 
 # v2 compatible wildly permissive profile
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   capability,
   network,
   / rwkl,

--- a/data/templates/ubuntu/1.1/ubuntu-sdk
+++ b/data/templates/ubuntu/1.1/ubuntu-sdk
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   #include <abstractions/X>

--- a/data/templates/ubuntu/1.1/ubuntu-webapp
+++ b/data/templates/ubuntu/1.1/ubuntu-webapp
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   #include <abstractions/X>

--- a/data/templates/ubuntu/1.2/ubuntu-account-plugin
+++ b/data/templates/ubuntu/1.2/ubuntu-account-plugin
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   #include <abstractions/X>

--- a/data/templates/ubuntu/1.2/ubuntu-scope-network
+++ b/data/templates/ubuntu/1.2/ubuntu-scope-network
@@ -4,7 +4,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/private-files-strict>
 

--- a/data/templates/ubuntu/1.3/ubuntu-sdk
+++ b/data/templates/ubuntu/1.3/ubuntu-sdk
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   #include <abstractions/X>

--- a/data/templates/ubuntu/15.10/ubuntu-account-plugin
+++ b/data/templates/ubuntu/15.10/ubuntu-account-plugin
@@ -14,7 +14,7 @@
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/fonts>
   #include <abstractions/X>


### PR DESCRIPTION
Since the upgrade to Qt 5.12 QTemporaryFile runs into the issue of hard-linking files
(based on their fd in `/proc/$PID/fd`) in TMPDIR which the default AppArmor behavior prevents.

The way snapd solved it was by applying the 'mediate_deleted' flag
in addition to 'attach_disconnected' to each profile, so let's mimic that.

More information: https://bugs.launchpad.net/apparmor/+bug/1772097