### PR TITLE
networking: Allow use of datagram netlink sockets

### DIFF
--- a/data/policygroups/ubuntu/1.0/networking
+++ b/data/policygroups/ubuntu/1.0/networking
@@ -103,3 +103,7 @@ deny dbus (receive, send)
 deny dbus (receive, send)
      bus=system
      interface="org.ofono.Manager",
+
+# Qt 5.11 and up uses AF_NETLINK datagram sockets directly for most
+# QNetworkInterface tasks.
+network netlink dgram,


### PR DESCRIPTION
This change allows the use of AF_NETLINK SOCK_DGRAM type networking for apps which have the networking policy group.

Qt started using these socket types in 5.11 (commit 4d31fc91 in qtbase). This allows Qt to see more information about the networking system than its old `getifaddrs()` method, but triggered an apparmor policy for us.

Fixes https://github.com/ubports/ubuntu-touch/issues/1680

References:
https://github.com/snapcore/snapd/pull/8792/commits/ecd394b86d2718dab228e1362fd14ae7769101f0
https://github.com/qt/qtbase/commit/4d31fc919b685df3f881a996a7de70ff1ba14cd2
https://forum.snapcraft.io/t/moonlight-mdns-broken-with-apparmor-denials-for-af-netlink-since-update-to-qt-5-12/17549